### PR TITLE
Fix Streaming Listing fetching new page for each next item

### DIFF
--- a/RedditSharp/Listing.cs
+++ b/RedditSharp/Listing.cs
@@ -424,36 +424,40 @@ namespace RedditSharp
             private async Task<bool> MoveNextForwardAsync(CancellationToken cancellationToken)
             {
                 CurrentIndex++;
-                int tries = 0;
-                while (true)
+
+                if (MaximumLimit != -1 && Count >= MaximumLimit)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    tries++;
+                    return false;
+                }
 
-                    if (MaximumLimit != -1 && Count >= MaximumLimit)
+                if (CurrentIndex >= CurrentPage.Count)
+                {
+                    int tries = 0;
+                    while (true)
                     {
-                        return false;
-                    }
+                        cancellationToken.ThrowIfCancellationRequested();
+                        tries++;
 
-                    try
-                    {
-                        await FetchNextPageAsync().ConfigureAwait(false);
-                        CurrentIndex = 0;
-                    }
-                    catch (Exception ex)
-                    {
-                        // sleep for a while to see if we can recover
-                        await Sleep(tries, cancellationToken, ex).ConfigureAwait(false);
-                    }
+                        try
+                        {
+                            await FetchNextPageAsync().ConfigureAwait(false);
+                            CurrentIndex = 0;
+                        }
+                        catch (Exception ex)
+                        {
+                            // sleep for a while to see if we can recover
+                            await Sleep(tries, cancellationToken, ex).ConfigureAwait(false);
+                        }
 
-                    // the page is only populated if there are *new* items to yielded from the listing.
-                    if (CurrentPage.Count > 0)
-                    {
-                        break;
-                    }
+                        // the page is only populated if there are *new* items to yielded from the listing.
+                        if (CurrentPage.Count > 0)
+                        {
+                            break;
+                        }
 
-                    // No listings were returned in the page.
-                    await Sleep(tries, cancellationToken).ConfigureAwait(false);
+                        // No listings were returned in the page.
+                        await Sleep(tries, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 Count++;
                 return true;

--- a/RedditSharpTests/Things/SubredditTests.cs
+++ b/RedditSharpTests/Things/SubredditTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -56,6 +57,22 @@ namespace RedditSharpTests.Things
 
             Assert.Equal(55, comments.Count);
             
+        }
+
+        [Fact]
+        public async Task StreamComments()
+        {
+            RedditSharp.WebAgent agent = new RedditSharp.WebAgent(authFixture.AccessToken);
+            RedditSharp.Reddit reddit = new RedditSharp.Reddit(agent, true);
+
+            var count = 0;
+            var comments = reddit.RSlashAll.GetComments().GetEnumerator(50, 100, true);
+            while (await comments.MoveNext(CancellationToken.None))
+            {
+                count++;
+            }
+
+            Assert.Equal(100, count);
         }
     }
 }


### PR DESCRIPTION
Fixes #184.

The problem was that on each `MoveNext` the listing fetched a new page, did not use the remaining items on the current one.