### PR TITLE
Add collection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ StyleCop.Cache
 /.vs
 /packages
 /RedditSharpTests/secrets.json
-/RedditSharpTests/private.config
+/RedditSharpTests/private.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ TestResults/
 *.mdf
 *.psess
 *.vsp
+.idea/
 
 /**/project.lock.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Development
 
-Use a private.config file to pull in config for tests. The required format is as follows
+Use a private.json file to pull in config for tests. The required format is as follows
 
 ```json
 {

--- a/RedditSharp/Data/Collections/AddOrRemovePostsFromCollectionParams.cs
+++ b/RedditSharp/Data/Collections/AddOrRemovePostsFromCollectionParams.cs
@@ -1,0 +1,17 @@
+namespace RedditSharp.Data.Collections
+{
+    internal class AddOrRemovePostsFromCollectionParams
+    {
+        /// <summary>
+        /// UUID of a collection
+        /// </summary>
+        [RedditAPIName("collection_id")]
+        internal string CollectionId { get; set; }
+
+        /// <summary>
+        /// Full name of link, e.g. t3_xyz
+        /// </summary>
+        [RedditAPIName("link_fullname")]
+        internal string LinkFullName { get; set; }
+    }
+}

--- a/RedditSharp/Data/Collections/CollectionCreationParams.cs
+++ b/RedditSharp/Data/Collections/CollectionCreationParams.cs
@@ -1,0 +1,23 @@
+namespace RedditSharp.Data.Collections
+{
+    internal class CollectionCreationParams
+    {
+        /// <summary>
+        /// Title of the submission. Maximum 300 characters.
+        /// </summary>
+        [RedditAPIName("title")]
+        internal string Title { get; set; }
+
+        /// <summary>
+        /// Description of the collection. Maximum of 500 characters.
+        /// </summary>
+        [RedditAPIName("description")]
+        internal string Description { get; set; }
+
+        /// <summary>
+        /// Name of the subreddit to which you are submitting.
+        /// </summary>
+        [RedditAPIName("sr_fullname")]
+        internal string Subreddit { get; set; }
+    }
+}

--- a/RedditSharp/Data/Collections/GetCollectionParams.cs
+++ b/RedditSharp/Data/Collections/GetCollectionParams.cs
@@ -1,0 +1,20 @@
+namespace RedditSharp.Data.Collections
+{
+    internal class CollectionBaseParams
+    {
+        /// <summary>
+        /// UUID of a collection
+        /// </summary>
+        [RedditAPIName("collection_id")]
+        internal string CollectionId { get; set; }
+    }
+
+    internal class GetCollectionParams : CollectionBaseParams
+    {
+        /// <summary>
+        /// Should include all the links
+        /// </summary>
+        [RedditAPIName("include_links")]
+        internal bool IncludeLinks { get; set; }
+    }
+}

--- a/RedditSharp/Data/Urls.cs
+++ b/RedditSharp/Data/Urls.cs
@@ -1,0 +1,15 @@
+namespace RedditSharp.Data
+{
+    internal static class Urls
+    {
+        internal static class Collections
+        {
+            internal const string AddPost = "/api/v1/collections/add_post_to_collection";
+            internal static string Get(string collectionId, bool includeLinks) => $"/api/v1/collections/collection.json?collection_id={collectionId}&include_links={includeLinks}";
+            internal const string CreateCollectionUrl = "/api/v1/collections/create_collection";
+            internal const string Delete = "/api/v1/collections/delete_collection";
+            internal const string RemovePost = "/api/v1/collections/remove_post_in_collection";
+            internal static string SubredditCollectionsUrl(string fullName) => $"/api/v1/collections/subreddit_collections.json?sr_fullname={fullName}";
+        } 
+    }
+}

--- a/RedditSharp/Exceptions/RedditException.cs
+++ b/RedditSharp/Exceptions/RedditException.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json.Linq;
 
 namespace RedditSharp
 {
@@ -8,6 +9,8 @@ namespace RedditSharp
     [Serializable]
     public class RedditException : Exception
     {
+        public JArray Errors { get; }
+
         /// <summary>
         /// Initializes a new instance of the RedditException class.
         /// </summary>
@@ -24,6 +27,17 @@ namespace RedditSharp
             : base(message)
         {
 
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the RedditException class with a specified error message and a JArray of errors
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="errors">List of errors.</param>
+        public RedditException(string message, JArray errors)
+            : base(message)
+        {
+            Errors = errors;
         }
 
         /// <summary>

--- a/RedditSharp/Extensions/JTokenExtensions/JTokenExtensions.cs
+++ b/RedditSharp/Extensions/JTokenExtensions/JTokenExtensions.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json.Linq;
+
+namespace RedditSharp.Extensions.JTokenExtensions
+{
+    public static class JTokenExtensions
+    {
+        public static void ThrowIfHasErrors(this JToken json, string message)
+        {
+            if (json["errors"].IsNonEmptyArray(out var errors))
+            {
+                throw new RedditException($"{message} {errors}", errors);
+            }
+        }
+
+        public static bool IsNonEmptyArray(this JToken json, out JArray array)
+        {
+            var isArray = _IsArray(json, out array);
+            return isArray && array.Count > 0;
+        }
+
+        private static bool _IsArray(JToken json, out JArray array)
+        {
+            if (json != null && json.Type == JTokenType.Array)
+            {
+                array = (JArray)json;
+                return true;
+            }
+            array = default;
+            return false;
+
+        }
+    }
+}

--- a/RedditSharp/Helpers/Helpers.PopulateObjects.cs
+++ b/RedditSharp/Helpers/Helpers.PopulateObjects.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using RedditSharp.Interfaces;
+
+namespace RedditSharp
+{
+    public partial class Helpers
+    {
+        internal static List<T> PopulateObjects<T>(JToken json, IWebAgent webAgent)
+            where T : ISettableWebAgent, new()
+        {
+            if (json.Type != JTokenType.Array)
+                throw new ArgumentException("must be of type array", nameof(json));
+
+            var objects = new List<T>();
+
+            for (var i = 0; i < json.Count(); i++)
+            {
+                var item = new T();
+                PopulateObject(json[i], item);
+                item.WebAgent = webAgent;
+                objects.Add(item);
+            }
+
+            return objects;
+        }
+    }
+}

--- a/RedditSharp/Interfaces/ISettableWebAgent.cs
+++ b/RedditSharp/Interfaces/ISettableWebAgent.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace RedditSharp.Interfaces
+{
+    internal interface ISettableWebAgent
+    {
+        [JsonIgnore]
+        IWebAgent WebAgent { set; }
+    }
+}

--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Security.Authentication;
 using System.Threading.Tasks;
+using RedditSharp.Data;
+using RedditSharp.Data.Collections;
+using RedditSharp.Extensions.JTokenExtensions;
 using DefaultWebAgent = RedditSharp.WebAgent;
 
 namespace RedditSharp
@@ -476,6 +479,24 @@ namespace RedditSharp
         public Listing<T> GetListing<T>(string url, int maxLimit = -1, int limitPerRequest = -1) where T : Thing
         {
             return new Listing<T>(this.WebAgent, url, maxLimit, limitPerRequest);
+        }
+
+        public async Task<Collection> GetCollectionAsync(string collectionId, bool includePostsContent = true)
+        {
+            var json = await WebAgent.Get(Urls.Collections.Get(collectionId, includePostsContent));
+            json.ThrowIfHasErrors("Could not retrieve the collection.");
+            return new Collection(json, WebAgent);
+        }
+
+        /// <summary>
+        /// Deletes the specified collection. Must be a mod of the subreddit to delete.
+        /// </summary>
+        /// <param name="collectionId"></param>
+        /// <returns></returns>
+        public async Task DeleteCollectionAsync(string collectionId)
+        {
+            var json = await WebAgent.Post(Urls.Collections.Delete, new CollectionBaseParams { CollectionId = collectionId });
+            json.ThrowIfHasErrors("Could not delete the collection.");
         }
     }
 }

--- a/RedditSharp/RedditSharp.csproj
+++ b/RedditSharp/RedditSharp.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
-	  <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
     <PackageReference Include="System.Interactive.Async" Version="3.1.1" />

--- a/RedditSharp/Things/Collection.cs
+++ b/RedditSharp/Things/Collection.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RedditSharp.Data;
+using RedditSharp.Data.Collections;
+using RedditSharp.Extensions.JTokenExtensions;
+using RedditSharp.Interfaces;
+
+namespace RedditSharp.Things
+{
+    public class Collection : ISettableWebAgent
+    {
+        [JsonProperty("subreddit_id")]
+        public string SubredditId { get; internal set; }
+
+        [JsonProperty("description")]
+        public string Description { get; internal set; }
+
+        [JsonProperty("author_name")]
+        public string AuthorName { get; internal set; }
+
+        [JsonProperty("collection_id")]
+        public string CollectionId { get; internal set; }
+
+        [JsonProperty("display_layout")]
+        public string DisplayLayout { get; internal set; }
+
+        [JsonProperty("permalink")]
+        public string Permalink { get; internal set; }
+
+        [JsonProperty("link_ids")]
+        public string[] LinkIds { get; internal set; }
+
+        [JsonProperty("title")]
+        public string Title { get; internal set; }
+
+        [JsonProperty("created_at_utc"), JsonConverter(typeof(UnixTimestampConverter))]
+        public DateTime CreatedAtUtc { get; internal set; }
+
+        [JsonProperty("author_id")]
+        public string AuthorId { get; internal set; }
+
+        [JsonProperty("last_update_utc"), JsonConverter(typeof(UnixTimestampConverter))]
+        public DateTime LastUpdateUtc { get; internal set; }
+
+        public Post[] Posts { get; }
+
+        public IWebAgent WebAgent { private get; set; }
+
+        public Collection()
+        {
+        }
+
+        public Collection(JToken json, IWebAgent agent)
+        {
+            WebAgent = agent;
+
+            Helpers.PopulateObject(json, this);
+            
+            var posts = new List<Post>();
+            var children = json.SelectToken("sorted_links.data.children");
+            if (children != null && children.Type == JTokenType.Array)
+            {
+                posts.AddRange(children.Select(item => new Post(WebAgent, item)));
+            }
+
+            Posts = posts.ToArray();
+        }
+
+        /// <summary>
+        /// Adds a post to the collection
+        /// </summary>
+        /// <param name="linkFullName">Full name of link, e.g. t3_xyz</param>
+        public async Task AddPostAsync(string linkFullName)
+        {
+            var data = new AddOrRemovePostsFromCollectionParams
+            {
+                CollectionId = CollectionId,
+                LinkFullName = linkFullName,
+            };
+            var json = await WebAgent.Post(Urls.Collections.AddPost, data);
+            json.ThrowIfHasErrors("Could not add post to collection.");
+        }
+
+        /// <summary>
+        /// Removes a post from the collection
+        /// </summary>
+        /// <param name="linkFullName">Full name of link, e.g. t3_xyz</param>
+        public async Task RemovePostAsync(string linkFullName)
+        {
+            var data = new AddOrRemovePostsFromCollectionParams
+            {
+                CollectionId = CollectionId,
+                LinkFullName = linkFullName,
+            };
+            var json = await WebAgent.Post(Urls.Collections.RemovePost, data);
+            json.ThrowIfHasErrors("Could not remove post from collection.");
+        }
+
+        public async Task DeleteAsync()
+        {
+            var json = await WebAgent.Post(Urls.Collections.Delete, null);
+            json.ThrowIfHasErrors("Could not remove collection.");
+        }
+    }
+}

--- a/RedditSharp/Things/Subreddit.cs
+++ b/RedditSharp/Things/Subreddit.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using RedditSharp.Data;
+using RedditSharp.Data.Collections;
+using RedditSharp.Extensions.JTokenExtensions;
 
 namespace RedditSharp.Things
 {
@@ -934,6 +937,28 @@ namespace RedditSharp.Things
         {
             var url = $"{ModLogUrl}?type={action}";
             return Listing<ModAction>.Create(WebAgent, url, max, 500);
+        }
+
+        public async Task<Collection> CreateCollectionAsync(string title, string description)
+        {
+            var data = new CollectionCreationParams
+            {
+                Subreddit = FullName,
+                Title = title,
+                Description = description,
+            };
+            var json = await WebAgent.Post(Urls.Collections.CreateCollectionUrl, data).ConfigureAwait(false);
+            json.ThrowIfHasErrors("Could not create collection.");
+            var result = new Collection(json, WebAgent);
+            return result;
+        }
+
+        public async Task<List<Collection>> GetCollectionsAsync()
+        {
+            var json = await WebAgent.Get(Urls.Collections.SubredditCollectionsUrl(FullName)).ConfigureAwait(false);
+            json.ThrowIfHasErrors("Could not retrieve collections.");
+            var result = Helpers.PopulateObjects<Collection>(json, WebAgent);
+            return result;
         }
 
         #region Static Operations

--- a/RedditSharpTests/AuthenticatedTestsFixture.cs
+++ b/RedditSharpTests/AuthenticatedTestsFixture.cs
@@ -12,7 +12,7 @@ namespace RedditSharpTests
         public AuthenticatedTestsFixture()
         {
             ConfigurationBuilder builder = new ConfigurationBuilder();
-            builder.AddJsonFile("private.config",true)
+            builder.AddJsonFile("private.json",true)
             .AddEnvironmentVariables();
             Config = builder.Build();
             WebAgent = new RedditSharp.BotWebAgent(Config["TestUserName"], Config["TestUserPassword"], Config["RedditClientID"], Config["RedditClientSecret"], Config["RedditRedirectURI"]);

--- a/RedditSharpTests/Collections/CollectionTests.cs
+++ b/RedditSharpTests/Collections/CollectionTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using RedditSharp;
+using RedditSharp.Things;
+using Retry;
+using Xunit;
+
+namespace RedditSharpTests.Collections
+{
+    [Collection("AuthenticatedTests")]
+    public class CollectionTests
+    {
+        private readonly Reddit _reddit;
+        private readonly string _subredditName;
+
+        public CollectionTests(AuthenticatedTestsFixture authenticatedFixture)
+        {
+            var authFixture = authenticatedFixture;
+            var agent = new WebAgent(authFixture.AccessToken);
+            _reddit = new Reddit(agent, true);
+            _subredditName = authFixture.Config["TestSubreddit"];
+        }
+
+        [SkippableFact]
+        public async Task CreatingACollection()
+        {
+            var guid = GenerateGuid();
+            var currentDate = DateTime.UtcNow.AddMinutes(-2);
+
+            var sub = await _reddit.GetSubredditAsync(_subredditName);
+            SkipIfNotModerator(sub);
+
+            var title = $"A collection with no posts {guid}";
+            var description = $"Collection description {GenerateGuid()}";
+
+            var result = await sub.CreateCollectionAsync(title, description);
+
+            Assert.Equal(description, result.Description);
+            Assert.Equal(title, result.Title);
+            Assert.Equal(sub.FullName, result.SubredditId);
+            Assert.True(result.CreatedAtUtc >= currentDate);
+            Assert.True(result.LastUpdateUtc >= currentDate);
+
+            var collections = await sub.GetCollectionsAsync();
+            Assert.True(collections.Count >= 1, "there should be at least one collection");
+            var collection = collections.FirstOrDefault(x => x.CollectionId == result.CollectionId);
+            Assert.NotNull(collection);
+
+            await _reddit.DeleteCollectionAsync(collection.CollectionId);
+        }
+
+        [SkippableFact]
+        public async Task CreatingACollectionAndAddingPosts()
+        {
+            var post1Guid = GenerateGuid();
+            var post2Guid = GenerateGuid();
+            var title = $"Collection of {post1Guid} and {post2Guid}";
+            var description = $"Awesome new collection {GenerateGuid()}";
+
+            var sub = await _reddit.GetSubredditAsync(_subredditName);
+            SkipIfNotModerator(sub);
+
+            var post1Task = sub.SubmitPostAsync($"Post {post1Guid}", "https://github.com/CrustyJew/RedditSharp", resubmit: true);
+            var post2Task = sub.SubmitTextPostAsync($"Post {post2Guid}", $"Post {post2Guid}");
+
+            var createCollectionTask = sub.CreateCollectionAsync(title, description);
+
+            var post1 = await post1Task;
+            var post2 = await post2Task;
+            var collectionResult = await createCollectionTask;
+
+            Assert.NotNull(post1);
+            Assert.NotNull(post2);
+
+            var addPost1Task = collectionResult.AddPostAsync(post1.FullName);
+            var addPost2Task = collectionResult.AddPostAsync(post2.FullName);
+
+            await addPost1Task;
+            await addPost2Task;
+
+            var collection = await RetryHelper.Instance
+                .Try(() => _reddit.GetCollectionAsync(collectionResult.CollectionId))
+                .WithTryInterval(TimeSpan.FromSeconds(0.5))
+                .WithMaxTryCount(10)
+                .Until(c => c.LinkIds.Length > 1);
+
+            Assert.Equal(2, collection.LinkIds.Length);
+            Assert.Contains(post1.FullName, collection.LinkIds);
+            Assert.Contains(post2.FullName, collection.LinkIds);
+
+            Assert.Equal(2, collection.Posts.Length);
+
+            var collectionWithLinkContent = await _reddit.GetCollectionAsync(collectionResult.CollectionId, includePostsContent: false);
+
+            Assert.Empty(collectionWithLinkContent.Posts);
+
+            await _reddit.DeleteCollectionAsync(collection.CollectionId);
+        }
+
+        [Fact]
+        public async Task DeletingANonExistentCollection()
+        {
+            var exception =  await Assert.ThrowsAsync<RedditException>(() => _reddit.DeleteCollectionAsync("00000000-0000-0000-1111-111111111111"));
+            Assert.Contains(exception.Errors, error => error[0].ToString().Equals("INVALID_COLLECTION_ID"));
+        }
+
+        private void SkipIfNotModerator(Subreddit sub)
+        {
+            Skip.If(sub.UserIsModerator != true, $"User isn't a moderator of ${_subredditName} so a collection cannot be made.");
+        }
+
+        private static string GenerateGuid()
+        {
+            return Guid.NewGuid().ToString("N").Substring(0, 5);
+        }
+    }
+}

--- a/RedditSharpTests/RedditSharpTests.csproj
+++ b/RedditSharpTests/RedditSharpTests.csproj
@@ -20,10 +20,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="RetryHelper" Version="2.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RedditSharpTests/RedditSharpTests.csproj
+++ b/RedditSharpTests/RedditSharpTests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="private.config">
+    <None Update="private.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="secrets.json">

--- a/RedditSharpTests/RedditSharpTests.csproj
+++ b/RedditSharpTests/RedditSharpTests.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>RedditSharpTests</AssemblyName>
     <PackageId>RedditSharpTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-RedditSharpTests</UserSecretsId>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,24 +14,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds support for:

`/api/v1/collections/add_post_to_collection`
`/api/v1/collections/collection`
`/api/v1/collections/create_collection`
`/api/v1/collections/delete_collection`
`/api/v1/collections/subreddit_collections`

To-do:
`/api/v1/collections/remove_post_in_collection`
`/api/v1/collections/follow_collection`
`/api/v1/collections/reorder_collection`
`/api/v1/collections/update_collection_description`
`/api/v1/collections/update_collection_display_layout`
`/api/v1/collections/update_collection_title`

This branch is based on `chasedog:fix-build-and-update-packages`. I will rebase once that's merged.