### PR TITLE
Obsoletes Created, giving API consumers info (#206).

### DIFF
--- a/RedditSharp/Things/CreatedThing.cs
+++ b/RedditSharp/Things/CreatedThing.cs
@@ -19,8 +19,17 @@ namespace RedditSharp.Things
         /// <summary>
         /// DateTime when the item was created.
         /// </summary>
+        /// <remarks>
+        /// This property is broken, as it returns the timestamp with the time
+        /// zone of the server that served the page. This is almost always
+        /// completely useless and any new code should use <see cref="CreatedUTC"/>
+        /// instead. <a href="https://www.reddit.com/comments/29991t">This 
+        /// /r/redditdev post</a> explains more.
+        /// </remarks>
+        /// <seealso cref="CreatedUTC"/>
         [JsonProperty("created")]
         [JsonConverter(typeof(UnixTimestampConverter))]
+        [Obsolete("Use the CreatedUTC property. This property is buggy and is kept for backwards compatability.")]
         public DateTime Created { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
Kinda fixes #206 to the best of our ability. This PR obsoletes the Created attribute and adds documentation which provides more information on why.