### PR TITLE
Resolve #219 - Handle t1__ more objects

### DIFF
--- a/RedditSharp/Reddit.cs
+++ b/RedditSharp/Reddit.cs
@@ -351,7 +351,7 @@ namespace RedditSharp
                 name = name.Substring(3);
 
             var url = string.Format(GetCommentUrl, subreddit, linkName, name);
-            return GetCommentAsync(new Uri(url));
+            return GetCommentAsync(new Uri(url, UriKind.Relative));
         }
 
         /// <summary>
@@ -361,7 +361,7 @@ namespace RedditSharp
         /// <returns></returns>
         public async Task<Comment> GetCommentAsync(Uri uri)
         {
-            var url = string.Format(GetPostUrl, uri.AbsoluteUri);
+            var url = string.Format(GetPostUrl, uri.ToString());
             var json = await WebAgent.Get(url).ConfigureAwait(false);
             var sender = new Post(WebAgent, json[0]["data"]["children"][0]);
             return new Comment(WebAgent, json[1]["data"]["children"][0], sender);

--- a/RedditSharp/Things/Comment.cs
+++ b/RedditSharp/Things/Comment.cs
@@ -102,7 +102,17 @@ namespace RedditSharp.Things
             if (replies != null && replies.Count() > 0)
             {
                 foreach (var comment in replies["data"]["children"])
-                    subComments.Add(new Comment(WebAgent, comment, sender));
+                {
+                    if (comment.Value<string>("kind") != "more")
+                    {
+                        subComments.Add(new Comment(WebAgent, comment, sender));
+                    }
+                    else
+                    {
+                        More = (new More(WebAgent, comment));
+                    }
+                    
+                }
             }
             Comments = subComments.ToArray();
         }

--- a/RedditSharp/Things/Post.cs
+++ b/RedditSharp/Things/Post.cs
@@ -288,7 +288,7 @@ namespace RedditSharp.Things
         /// </summary>
         /// <param name="limit">Maximum number of comments to return. Returned list may be larger than this number though due to <see cref="More"/></param>
         /// <returns></returns>
-        public async Task<List<Thing>> GetCommentsWithMoresAsync(int limit = 0, CommentSort sort = CommentSort.Best)
+        public async Task<List<Thing>> GetCommentsWithMoresAsync(int limit = 0, CommentSort sort = CommentSort.Best, int depth=0)
         {
             var url = string.Format(GetCommentsUrl, Id);
 
@@ -305,6 +305,11 @@ namespace RedditSharp.Things
             if (limit > 0)
             {
                 url = $"{url}&limit={limit}";
+            }
+
+            if(depth > 0)
+            {
+                url = $"{url}&depth={depth}";
             }
 
             var json = await WebAgent.Get(url).ConfigureAwait(false);

--- a/RedditSharpTests/Things/PostTests.cs
+++ b/RedditSharpTests/Things/PostTests.cs
@@ -42,6 +42,22 @@ namespace RedditSharpTests.Things
             Assert.Equal(10, comments.Count);
 
         }
+        [Fact]
+        public async Task GetCommentsWithMoresAsync()
+        {
+            RedditSharp.WebAgent agent = new RedditSharp.WebAgent(authFixture.AccessToken);
+            RedditSharp.Reddit reddit = new RedditSharp.Reddit(agent);
+            var post = (Post)await reddit.GetThingByFullnameAsync("t3_f1bo6u");
+
+            var things = await post.GetCommentsWithMoresAsync(limit: 9, depth: 2);
+            Assert.NotEmpty(things);
+            Assert.Equal(typeof(More), things.Last().GetType());
+            Assert.NotNull(((Comment)things[0]).More);
+            Assert.NotNull(((Comment)things[0]).Comments[0].More);
+
+        }
+
+
 
         [Fact]
         public async Task EnumerateAllComments()
@@ -59,5 +75,7 @@ namespace RedditSharpTests.Things
             Assert.Equal(25, commentsList.Count);
 
         }
+
+ 
     }
 }


### PR DESCRIPTION
Builds on @czf 's changes in PR [224](https://github.com/CrustyJew/RedditSharp/pull/224/files) to allow for `More` in Comment response.

Resolves #219 and now handles "Continue this thread" `More`-like objects eg:

```JSON
{
  "count": 0,
  "name": "t1__",
  "id": "_",
  "parent_id": "t1_cydnx3d",	
  "depth": 10,
  "children": []
}
```